### PR TITLE
enable airCon and switch mode on Mitsubishi outlander 2019 PHEV(0.0600.3.000)

### DIFF
--- a/include/phevargs.h
+++ b/include/phevargs.h
@@ -15,6 +15,7 @@
 #define BATTERY "battery"
 #define AIRCON "aircon"
 #define AIRCON_MODE "acmode"
+#define AIRCON_MY19 "airconmode"
 #define REGISTER "register"
 #define MONITOR "monitor"
 #define GET "get"
@@ -36,6 +37,7 @@ typedef enum phev_args_commands_t {
     CMD_BATTERY,
     CMD_AIRCON,
     CMD_AIRCON_MODE,
+    CMD_AIRCON_MY19,
     CMD_GET_REG_VAL,
     CMD_DISPLAY_REG,
 } phev_args_commands_t;
@@ -64,13 +66,13 @@ static uint8_t PHEV_ARGS_DEFAULT_MAC[] = {0,0,0,0,0,0};
 static const char * phev_args_argp_program_version = "Version\t" VERSION;
 static const char * phev_args_argp_program_bug_address = "jamie@wattu.com";
 static char phev_args_doc[] = "\n\nProgram to control the car via the remote WiFi interface.  Requires this device to be connected to the REMOTE**** access point with a valid IP address, which is on the 192.168.8.x subnet.\n\nTHIS PROGRAM COMES WITH NO WARRANTY ANY DAMAGE TO THE CAR OR ANY OTHER EQUIPMENT IS AT THE USERS OWN RISK.";
-static char phev_args_args_doc[] = "register\nbattery\naircon [on|off]\nacmode [heat|cool|windscreen] [10|20|30]\nheadlights [on|off]\nparkinglights [on|off]\nmonitor\nget <register>";
-static struct argp_option phev_args_options[] = { 
+static char phev_args_args_doc[] = "register\nbattery\naircon [on|off]\nacmode [heat|cool|windscreen] [10|20|30]\nairconmode [heat|cool|windscreen] [10|20|30]\nheadlights [on|off]\nparkinglights [on|off]\nmonitor\nget <register>";
+static struct argp_option phev_args_options[] = {
     { "mac", 'm', "<MAC ADDRESS>",0, "MAC address."},
     { "host", 'h', "<HOST NAME>",OPTION_HIDDEN, "IP address of car - defaults to 192.168.8.46."},
     { "port", 'p', "<PORT NUMBER>",OPTION_HIDDEN, "Port to use - defaults to 8080"},
     { "verbose",'v',0,0,"Verbose output"},
-    { 0 } 
+    { 0 }
 };
 phev_args_opts_t * phev_args_parse(int argc, char *argv[]);
 

--- a/include/phevargs.h
+++ b/include/phevargs.h
@@ -15,7 +15,6 @@
 #define BATTERY "battery"
 #define AIRCON "aircon"
 #define AIRCON_MODE "acmode"
-#define AIRCON_MY19 "airconmode"
 #define REGISTER "register"
 #define MONITOR "monitor"
 #define GET "get"
@@ -37,7 +36,6 @@ typedef enum phev_args_commands_t {
     CMD_BATTERY,
     CMD_AIRCON,
     CMD_AIRCON_MODE,
-    CMD_AIRCON_MY19,
     CMD_GET_REG_VAL,
     CMD_DISPLAY_REG,
 } phev_args_commands_t;
@@ -51,6 +49,7 @@ typedef struct phev_args_opts_t {
     char * topic;
     char * command_topic;
     bool verbose;
+    int carModel;
     bool operand_on;
     uint8_t operand_mode;
     uint8_t operand_time;
@@ -66,9 +65,10 @@ static uint8_t PHEV_ARGS_DEFAULT_MAC[] = {0,0,0,0,0,0};
 static const char * phev_args_argp_program_version = "Version\t" VERSION;
 static const char * phev_args_argp_program_bug_address = "jamie@wattu.com";
 static char phev_args_doc[] = "\n\nProgram to control the car via the remote WiFi interface.  Requires this device to be connected to the REMOTE**** access point with a valid IP address, which is on the 192.168.8.x subnet.\n\nTHIS PROGRAM COMES WITH NO WARRANTY ANY DAMAGE TO THE CAR OR ANY OTHER EQUIPMENT IS AT THE USERS OWN RISK.";
-static char phev_args_args_doc[] = "register\nbattery\naircon [on|off]\nacmode [heat|cool|windscreen] [10|20|30]\nairconmode [heat|cool|windscreen] [10|20|30]\nheadlights [on|off]\nparkinglights [on|off]\nmonitor\nget <register>";
+static char phev_args_args_doc[] = "register\nbattery\naircon [on|off]\nacmode [heat|cool|windscreen] [10|20|30]\nheadlights [on|off]\nparkinglights [on|off]\nmonitor\nget <register>";
 static struct argp_option phev_args_options[] = {
     { "mac", 'm', "<MAC ADDRESS>",0, "MAC address."},
+    { "car-model", 'c', "<YEAR>",0, "Model Year."},
     { "host", 'h', "<HOST NAME>",OPTION_HIDDEN, "IP address of car - defaults to 192.168.8.46."},
     { "port", 'p', "<PORT NUMBER>",OPTION_HIDDEN, "Port to use - defaults to 8080"},
     { "verbose",'v',0,0,"Verbose output"},

--- a/main.c
+++ b/main.c
@@ -153,13 +153,16 @@ static int main_eventHandler(phevEvent_t *event)
             case CMD_AIRCON_MODE:
             {
                 printf("Switching air conditioning mode to %d for %d mins\n", opts->operand_mode, opts->operand_time);
-                phev_airConMode(event->ctx, opts->operand_mode, opts->operand_time, operationCallback);
-                break;
-            }
-            case CMD_AIRCON_MY19:
-            {
-                printf("Switching air conditioning mode to %d for %d mins\n", opts->operand_mode, opts->operand_time);
-                phev_airConMY19(event->ctx, opts->operand_mode, opts->operand_time, operationCallback);
+                if (opts->verbose)
+                {
+                    printf("Car Model: %d\n", opts->carModel);
+                }
+                if ( opts->carModel == 2019){
+                    phev_airConMY19(event->ctx, opts->operand_mode, opts->operand_time, operationCallback);
+                } else {
+                    phev_airConMode(event->ctx, opts->operand_mode, opts->operand_time, operationCallback);
+                }
+
                 break;
             }
             }

--- a/main.c
+++ b/main.c
@@ -156,6 +156,12 @@ static int main_eventHandler(phevEvent_t *event)
                 phev_airConMode(event->ctx, opts->operand_mode, opts->operand_time, operationCallback);
                 break;
             }
+            case CMD_AIRCON_MY19:
+            {
+                printf("Switching air conditioning mode to %d for %d mins\n", opts->operand_mode, opts->operand_time);
+                phev_airConMY19(event->ctx, opts->operand_mode, opts->operand_time, operationCallback);
+                break;
+            }
             }
         }
         return 0;
@@ -253,7 +259,7 @@ int main(int argc, char *argv[])
 
         switch(ch)
         {
-        case 'r': 
+        case 'r':
         {
             printf("Disconnecting\n");
             phev_disconnect(ctx);

--- a/src/phevargs.c
+++ b/src/phevargs.c
@@ -23,14 +23,6 @@ int phev_args_validate(int arg_num,phev_args_opts_t * opts)
             }
             break;
         }
-        case CMD_AIRCON_MY19:
-        {
-            if(arg_num == 3)
-            {
-                return 0;
-            }
-            break;
-        }
         case CMD_REGISTER:
         {
             if(arg_num == 1)
@@ -102,7 +94,6 @@ int phev_args_process_operands(char * arg, int arg_num, phev_args_opts_t * opts)
             opts->error_message = "Too many operands";
             break;
         }
-        case CMD_AIRCON_MY19:
         case CMD_AIRCON_MODE:
         {
             if(arg_num == 1)
@@ -193,10 +184,6 @@ int phev_args_process_command(char * arg, int arg_num, phev_args_opts_t * opts)
     {
         opts->command = CMD_AIRCON;
     }
-    if(strcmp(arg,AIRCON_MY19) == 0 && arg_num == 0)
-    {
-        opts->command = CMD_AIRCON_MY19;
-    }
     if(strcmp(arg,GET) == 0 && arg_num == 0)
     {
         opts->command = CMD_GET_REG_VAL;
@@ -274,6 +261,10 @@ static error_t phev_args_parse_opt(int key, char *arg, struct argp_state *state)
     }
     case 'v': {
         opts->verbose = true;
+        break;
+    }
+    case 'c': {
+        opts->carModel = atoi(arg);
         break;
     }
     case ARGP_KEY_END:

--- a/src/phevargs.c
+++ b/src/phevargs.c
@@ -7,7 +7,7 @@ int phev_args_validate(int arg_num,phev_args_opts_t * opts)
     {
         case CMD_HEADLIGHTS:
         case CMD_PARKING_LIGHTS:
-        case CMD_AIRCON: 
+        case CMD_AIRCON:
         {
             if(arg_num == 2)
             {
@@ -16,6 +16,14 @@ int phev_args_validate(int arg_num,phev_args_opts_t * opts)
             break;
         }
         case CMD_AIRCON_MODE:
+        {
+            if(arg_num == 3)
+            {
+                return 0;
+            }
+            break;
+        }
+        case CMD_AIRCON_MY19:
         {
             if(arg_num == 3)
             {
@@ -79,7 +87,7 @@ int phev_args_process_operands(char * arg, int arg_num, phev_args_opts_t * opts)
                 {
                     opts->operand_on = true;
                     break;
-                } 
+                }
                 if(strcmp(arg,OFF) == 0)
                 {
                     opts->operand_on = false;
@@ -89,11 +97,12 @@ int phev_args_process_operands(char * arg, int arg_num, phev_args_opts_t * opts)
                 opts->error_message = "Operand must be on or off";
                 break;
             }
-            
+
             opts->error = true;
             opts->error_message = "Too many operands";
             break;
         }
+        case CMD_AIRCON_MY19:
         case CMD_AIRCON_MODE:
         {
             if(arg_num == 1)
@@ -116,14 +125,14 @@ int phev_args_process_operands(char * arg, int arg_num, phev_args_opts_t * opts)
                 opts->error = true;
                 opts->error_message = "Unrecognised operand";
                 break;
-            } 
-            
+            }
+
             if(arg_num == 2)
             {
                 if(strlen(arg) == 2 && isdigit(arg[0]) && isdigit(arg[1]))
                 {
                     opts->operand_time = atoi(arg);
-                
+
                     if(opts->operand_time != 10 &&
                         opts->operand_time != 20 &&
                         opts->operand_time != 30
@@ -131,23 +140,23 @@ int phev_args_process_operands(char * arg, int arg_num, phev_args_opts_t * opts)
                     {
                         opts->error = true;
                         opts->error_message = "Unrecognised operand";
-                        break;  
+                        break;
                     }
-                } 
-                else 
+                }
+                else
                 {
                     opts->error = true;
                     opts->error_message = "Unrecognised operand";
                 }
             }
-            break;   
+            break;
         }
         case CMD_GET_REG_VAL: {
             if(strlen(arg) == 2 && isdigit(arg[0]) && isdigit(arg[1]) && arg_num == 1)
             {
                 opts->reg_operand = atoi(arg);
-            } 
-            else 
+            }
+            else
             {
                 opts->error = true;
                 opts->error_message = "Not a number";
@@ -183,6 +192,10 @@ int phev_args_process_command(char * arg, int arg_num, phev_args_opts_t * opts)
     if(strcmp(arg,AIRCON) == 0 && arg_num == 0)
     {
         opts->command = CMD_AIRCON;
+    }
+    if(strcmp(arg,AIRCON_MY19) == 0 && arg_num == 0)
+    {
+        opts->command = CMD_AIRCON_MY19;
     }
     if(strcmp(arg,GET) == 0 && arg_num == 0)
     {
@@ -244,9 +257,9 @@ static error_t phev_args_parse_opt(int key, char *arg, struct argp_state *state)
         }
         opts->mac = PHEV_ARGS_DEFAULT_MAC;
         break;
-    } 
+    }
     case 'h': {
-        if(arg !=NULL) 
+        if(arg !=NULL)
         {
             opts->host = strdup(arg);
         }
@@ -276,7 +289,7 @@ static error_t phev_args_parse_opt(int key, char *arg, struct argp_state *state)
             opts->command = CMD_INVALID;
             printf("\nERROR : %s\n",opts->error_message);
             argp_usage(state);
-        } 
+        }
         break;
     }
     case ARGP_KEY_ARG: {
@@ -288,16 +301,16 @@ static error_t phev_args_parse_opt(int key, char *arg, struct argp_state *state)
             }
             break;
         }
-        
+
         if(phev_args_process_operands(strdup(arg), state->arg_num,opts))
         {
             opts->command = CMD_INVALID;
         }
         break;
     }
-        
+
     default: return ARGP_ERR_UNKNOWN;
-    }   
+    }
     return 0;
 }
 
@@ -320,6 +333,6 @@ phev_args_opts_t * phev_args_parse(int argc, char *argv[])
     arguments->error_message = "";
 
     argp_parse(&phev_args_argp, argc, argv, 0, 0, arguments);
-    
+
     return arguments;
 }


### PR DESCRIPTION
Part of https://github.com/phev-remote/phevcore/pull/10

Switching air condition mode on Outlander 2019 PHEV (0.0600.3.000)

```
phevctl --car-model=2019 acmode [heat|cool|windscreen] [10|20|30]
```